### PR TITLE
Add a linking fallback for cross compilation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -35,7 +35,10 @@ fn check_func(function_name: &str) -> bool {
 }
 
 fn main() {
-    pkg_config::find_library("libudev").unwrap();
+    if pkg_config::find_library("libudev").is_err() {
+        // fallback for cross-compilation
+        println!("cargo:link-target={}", "udev");
+    }
 
     if check_func("udev_hwdb_new") {
         println!("cargo:rustc-cfg=hwdb");


### PR DESCRIPTION
This is a fix for #7 based on a [similar fix](https://github.com/andrewshadura/bsd-pidfile-rs/pull/3) I did for bsd-pidfile-rs. It fixes cross compilation by assuming a reasonable default for libudev when pkg-config fails.

### Cross-Compilation Success!
```
$ cargo build --target=armv7-unknown-linux-gnueabihf
   Compiling libudev-sys v0.1.4 (/home/d1plo1d/git_repos/libudev-sys)
   Compiling libc v0.2.93
    Finished dev [unoptimized + debuginfo] target(s) in 0.78s
```