### PR TITLE
Use the cargo-supplied RUSTC environment variable.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -25,7 +25,8 @@ fn check_func(function_name: &str) -> bool {
         writeln!(&mut test_file, "}}").unwrap();
     }
 
-    let output = Command::new("rustc").
+    let rustc = env::var("RUSTC").unwrap();
+    let output = Command::new(rustc).
         arg(&test_file_name).
         arg("--out-dir").arg(&out_dir).
         arg("-l").arg("udev").


### PR DESCRIPTION
When executing build scripts, [cargo sets several environment variables](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts).
Use the cargo-supplied value for `RUSTC`.

This _also_ allows `libudev-sys` to be build by [bazel](https://bazel.build)
using rules created by `cargo raze`.

Signed-off-by: Chris Frantz <cfrantz@google.com>