### PR TITLE
build: Avoid to add unwanted system folder in library research paths

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -35,7 +35,9 @@ fn check_func(function_name: &str) -> bool {
 }
 
 fn main() {
-    pkg_config::find_library("libudev").unwrap();
+    pkg_config::Config::new()
+        .print_system_libs(false)
+        .probe("libudev").unwrap();
 
     if check_func("udev_hwdb_new") {
         println!("cargo:rustc-cfg=hwdb");


### PR DESCRIPTION
Default pkg-config-rs behavior is to add default system library paths (ex: `-L/usr/lib/x86_64-linux-gnu`).

This is because `PKG_CONFIG_ALLOW_SYSTEM_LIBS` is set by pkg-config-rs by default. `print_system_libs(false)` disable this behavior.

I had a similar issue with evdev-rs. There are more explanations about the issue here: https://github.com/ndesh26/evdev-rs/issues/85.