### PR TITLE
Update build.rs to read from RUSTC

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -25,7 +25,7 @@ fn check_func(function_name: &str) -> bool {
         writeln!(&mut test_file, "}}").unwrap();
     }
 
-    let output = Command::new("rustc").
+    let output = Command::new(env::var_os("RUSTC").unwrap()).
         arg(&test_file_name).
         arg("--out-dir").arg(&out_dir).
         arg("-l").arg("udev").


### PR DESCRIPTION
Cargo exposes `RUSTC` ([docs](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts)).