### PR TITLE
Use RUSTC env var to locate rustc in build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -24,8 +24,9 @@ fn check_func(function_name: &str) -> bool {
         writeln!(&mut test_file, "    }}").unwrap();
         writeln!(&mut test_file, "}}").unwrap();
     }
-
-    let output = Command::new("rustc").
+    
+    let rustc = env::var("RUSTC").unwrap();
+    let output = Command::new(rustc).
         arg(&test_file_name).
         arg("--out-dir").arg(&out_dir).
         arg("-l").arg("udev").


### PR DESCRIPTION
See https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts

This allows the library to be build when `rustc` is not in the PATH.