### PR TITLE
fix cross compilation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -25,7 +25,8 @@ fn check_func(function_name: &str) -> bool {
         writeln!(&mut test_file, "}}").unwrap();
     }
 
-    let output = Command::new("rustc").
+    let rustc = env::var("RUSTC").unwrap();
+    let output = Command::new(rustc).
         arg(&test_file_name).
         arg("--out-dir").arg(&out_dir).
         arg("-l").arg("udev").

--- a/build.rs
+++ b/build.rs
@@ -38,10 +38,9 @@ fn check_func(function_name: &str, lib: pkg_config::Library) -> bool {
     }
 
     cmd.args(["--target", &std::env::var("TARGET").unwrap()]);
-    cmd.args([
-        "-C",
-        &format!("linker={}", std::env::var("RUSTC_LINKER").unwrap()),
-    ]);
+    if let Ok(linker) = std::env::var("RUSTC_LINKER") {
+        cmd.args(["-C", &format!("linker={linker}")]);
+    }
 
     let output = cmd.output().unwrap();
     if !output.status.success() {
@@ -54,13 +53,13 @@ fn check_func(function_name: &str, lib: pkg_config::Library) -> bool {
             "cargo:warning=stdout={}",
             String::from_utf8_lossy(&output.stdout)
                 .trim()
-                .replace("\n", "\ncargo:warning=")
+                .replace('\n', "\ncargo:warning=")
         );
         println!(
             "cargo:warning=stderr={}",
             String::from_utf8_lossy(&output.stderr)
                 .trim()
-                .replace("\n", "\ncargo:warning=")
+                .replace('\n', "\ncargo:warning=")
         );
         false
     } else {
@@ -74,8 +73,7 @@ fn main() {
     if check_func("udev_hwdb_new", lib) {
         println!("cargo:rustc-cfg=hwdb");
         println!("cargo:hwdb=true");
-    }
-    else {
+    } else {
         println!("cargo:hwdb=false");
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 
 use std::io::prelude::*;
 
-fn check_func(function_name: &str) -> bool {
+fn check_func(function_name: &str, lib: pkg_config::Library) -> bool {
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let test_file_name = Path::new(&out_dir).join(format!("check_{}.rs", function_name));
 
@@ -24,21 +24,54 @@ fn check_func(function_name: &str) -> bool {
         writeln!(&mut test_file, "    }}").unwrap();
         writeln!(&mut test_file, "}}").unwrap();
     }
-
     let rustc = env::var("RUSTC").unwrap();
-    let output = Command::new(rustc).
-        arg(&test_file_name).
-        arg("--out-dir").arg(&out_dir).
-        arg("-l").arg("udev").
-        output().unwrap();
+    let mut cmd = Command::new(rustc);
 
-    output.status.success()
+    cmd.arg(&test_file_name).arg("--out-dir").arg(&out_dir);
+
+    for path in lib.link_paths {
+        cmd.arg("-L").arg(path);
+    }
+
+    for lib in lib.libs {
+        cmd.arg("-l").arg(lib);
+    }
+
+    cmd.args(["--target", &std::env::var("TARGET").unwrap()]);
+    cmd.args([
+        "-C",
+        &format!("linker={}", std::env::var("RUSTC_LINKER").unwrap()),
+    ]);
+
+    let output = cmd.output().unwrap();
+    if !output.status.success() {
+        println!(
+            "cargo:warning=Failed to compile test program for udev function `{}`",
+            function_name
+        );
+        println!("cargo:warning=Using command`{:?}`", cmd);
+        println!(
+            "cargo:warning=stdout={}",
+            String::from_utf8_lossy(&output.stdout)
+                .trim()
+                .replace("\n", "\ncargo:warning=")
+        );
+        println!(
+            "cargo:warning=stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+                .trim()
+                .replace("\n", "\ncargo:warning=")
+        );
+        false
+    } else {
+        true
+    }
 }
 
 fn main() {
-    pkg_config::find_library("libudev").unwrap();
+    let lib = pkg_config::probe_library("libudev").unwrap();
 
-    if check_func("udev_hwdb_new") {
+    if check_func("udev_hwdb_new", lib) {
         println!("cargo:rustc-cfg=hwdb");
         println!("cargo:hwdb=true");
     }


### PR DESCRIPTION
Fixes cross-rs/cross#1377

This fixes wrong assumptions done in the build script so that the correct link paths, linker and target are used.

includes #11