### PR TITLE
Properly link in libudev once it is found

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -25,23 +25,29 @@ fn check_func(function_name: &str) -> bool {
         writeln!(&mut test_file, "}}").unwrap();
     }
 
-    let output = Command::new("rustc").
-        arg(&test_file_name).
-        arg("--out-dir").arg(&out_dir).
-        arg("-l").arg("udev").
-        output().unwrap();
+    let output = Command::new("rustc")
+        .arg(&test_file_name)
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("-l")
+        .arg("udev")
+        .output()
+        .unwrap();
 
     output.status.success()
 }
 
 fn main() {
-    pkg_config::find_library("libudev").unwrap();
+    let library = pkg_config::find_library("libudev").unwrap();
+
+    for path in library.link_files {
+        println!("cargo:rustc-link-lib={}", path.display());
+    }
 
     if check_func("udev_hwdb_new") {
         println!("cargo:rustc-cfg=hwdb");
         println!("cargo:hwdb=true");
-    }
-    else {
+    } else {
         println!("cargo:hwdb=false");
     }
 }


### PR DESCRIPTION
This fixes a subtle issue where libudev-rs assumes that the library files are properly linked in which can result in a seemingly mysterious SIGSEGV when using a musl-based libc distribution.

See [https://github.com/probe-rs/probe-rs/issues/2148](https://github.com/probe-rs/probe-rs/issues/2148) for details.